### PR TITLE
Fix hamburger menu in Safari iOS

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -22,7 +22,7 @@ const NavLink = ({ href, children }: { href: string; children: React.ReactNode }
       passHref
       className={`${
         isActive ? "bg-secondary shadow-md" : ""
-      } hover:bg-secondary hover:shadow-md focus:!bg-secondary active:!text-neutral py-1.5 px-3 text-sm rounded-full gap-2 grid grid-flow-col items-center`}
+      } hover:bg-secondary hover:shadow-md focus:!bg-secondary active:!text-neutral py-1.5 px-3 text-sm rounded-full gap-2 flex items-center`}
     >
       {children}
     </Link>
@@ -45,25 +45,25 @@ export const Header = () => {
       <li>
         <NavLink href="/">
           <HomeIcon className="h-4 w-4" />
-          Home
+          <div className="grow text-center">Home</div>
         </NavLink>
       </li>
       <li>
         <NavLink href="/learn">
           <BookOpenIcon className="h-4 w-4" />
-          Learn
+          <div className="grow text-center">Learn</div>
         </NavLink>
       </li>
       <li>
         <NavLink href="/mint">
           <SparklesIcon className="h-4 w-4" />
-          Mint NFT
+          <div className="grow text-center">Mint NFT</div>
         </NavLink>
       </li>
       <li>
         <NavLink href="/share">
           <ShareIcon className="h-4 w-4" />
-          Share
+          <div className="grow text-center">Share</div>
         </NavLink>
       </li>
 


### PR DESCRIPTION
## Fix hamburger menu in Safari iOS

The hamburger menu in Safari mobile devices had a little bug:
<img src="https://github.com/luloxi/0-to-BuidlGuidl/assets/48974550/3fe8387c-ba20-4ed8-9a07-a0c7da9853a1" width="200" height="310">

This is because some some versions of Safari don't fully support grid, so I used flexbox to achieve the same appearance:
<img src="https://github.com/luloxi/0-to-BuidlGuidl/assets/48974550/0d992627-1f37-4c7c-9110-0e917988bac7" width="200" height="310">

I deployed the front end here so you can verify it in other iOS devices: https://0-to-buidl-guidl-fork-nextjs.vercel.app/

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: wildanvin.eth
